### PR TITLE
Removed uwanted space

### DIFF
--- a/compose/docker-compose.dev.yml
+++ b/compose/docker-compose.dev.yml
@@ -21,7 +21,7 @@ services:
       #- ./src/var/log:/var/www/html/var/log:cached
       #- ./src/var/report:/var/www/html/var/report:cached
       # To sync your SSH to the container, uncomment the following line:
-      # - ~/.ssh/id_rsa:/var/www/.ssh/id_rsa:cached
+      #- ~/.ssh/id_rsa:/var/www/.ssh/id_rsa:cached
       # Linux only: remove the above lines and mount the entire src directory with:
       #- ./src:/var/www/html:cached
 


### PR DESCRIPTION
This space can cause yaml validation error if someone uncomment the line. Aligned to other commented lines.